### PR TITLE
Adds the postgresql-data-k8s charm to the bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 In a nutshell, [Waltz](https://github.com/finos/waltz) allows you to visualize and define your organisation's technology landscape. Think of it like a structured Wiki for your architecture.
 
-This repository contains a [Juju](https://juju.is) bundle for FINOS Waltz, which will deploy and relate the following charms:
+This repository contains a [Juju](https://juju.is) bundle for FINOS Waltz. The **public** ``bundle.yaml`` additionally contains the ``postgresql-data-k8s`` charm. The bundle will deploy and relate the following charms:
 
 * [finos-waltz-k8s](https://github.com/pedroleaoc/waltz-integration-juju): contains the Waltz server.
 * [postgresql-k8s](https://charmhub.io/postgresql-k8s): responsible for creating a PostgreSQL database on demand for the related ``finos-waltz-k8s`` charm.
+* [postgresql-data-k8s](https://charmhub.io/postgresql-data-k8s): relates to the ``postgresql-k8s`` charm through the ``db-admin`` relation, and configured to update the Waltz database with a public dataset, which can be used for testing purposes. The charm is configured to periodically reset the dataset. For more information on the available configuration options, see [here](https://charmhub.io/postgresql-data-k8s)
 * [nginx-ingress-integrator](https://charmhub.io/nginx-ingress-integrator): manages the ingress traffic for the related ``finos-waltz-k8s`` charm, allowing users to connect to Waltz through a friendly, configurable ``service-hostname`` instead of an ephemeral IP. Can be further configured with other config options, such as ``tls-secret-name``, which will enable Ingress-terminated TLS for the Waltz service using the certificate stored in the given secret. For more information on the available configuration options, see [here](https://charmhub.io/nginx-ingress-integrator/configure).
 
 For more information on Waltz and how to deploy it using Juju, see the [FINOS Waltz Charm's README](https://github.com/pedroleaoc/waltz-integration-juju/blob/main/README.md) and [local deployment guide](https://github.com/pedroleaoc/waltz-integration-juju/blob/main/docs/LocalDeployment.md).

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -11,10 +11,27 @@ applications:
     channel: "stable"
     scale: 1
 
+  postgresql-data:
+    charm: "postgresql-data-k8s"
+    channel: "edge"
+    scale: 1
+    options:
+      # Refresh period is in minutes.
+      refresh-period: 120
+      # The sql-dump-url must be either .tar, or a .tar.gz
+      # postgres-dump-1.40.sql.gz is a .tar.gz, despite its name.
+      sql-dump-url: https://github.com/finos/waltz/files/8390039/postgres-dump-1.40.sql.gz
+      # Same db-name and db-user as the finos-waltz-k8s charm.
+      db-name: waltz
+      db-user: finos-waltz
+
   finos-waltz:
     charm: "finos-waltz-k8s"
     channel: "edge"
     scale: 1
+    options:
+      db-name: waltz
+      db-username: finos-waltz
 
   waltz-ingress:
     charm: "nginx-ingress-integrator"
@@ -25,5 +42,6 @@ applications:
 relations:
   # Waltz DB relation:
   - ["postgresql:db", "finos-waltz:db"]
+  - ["postgresql:db-admin", "postgresql-data:db-admin"]
   # Waltz ingress relation:
   - ["waltz-ingress", "finos-waltz"]


### PR DESCRIPTION
The ``postgresql-data-k8s`` charm can relate to the ``postgresql-k8s charm``'s ``db-admin`` relation, which will allow it to update the
configured database. This can be used to inject a public dataset, given through the ``sql-dump-url`` config option, and can be reset to that dump periodically.

This can be used for a public instance of Waltz, which contains a public dataset.